### PR TITLE
Support Sphinx 1.7

### DIFF
--- a/src/sphinxjp/themes/revealjs/directives.py
+++ b/src/sphinxjp/themes/revealjs/directives.py
@@ -10,7 +10,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst.roles import set_classes
 
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 from sphinxjp.themes.revealjs import compat
 


### PR DESCRIPTION
Most of `sphinx.util.compat` is removed in Sphinx 1.7. Use `Directive` from `docutils.parsers.rst` instead. Without this change, `sphinxjp.themes.revealjs` cannot be imported, and `sphinx-build` fails with:
```
Running Sphinx v1.7.3
loading translations [en]... done

Traceback (most recent call last):
  File "/home/ben/.local/lib/python2.7/site-packages/sphinx/cmdline.py", line 303, in main
    args.warningiserror, args.tags, args.verbosity, args.jobs)
  File "/home/ben/.local/lib/python2.7/site-packages/sphinx/application.py", line 191, in __init__
    self.setup_extension(extension)
  File "/home/ben/.local/lib/python2.7/site-packages/sphinx/application.py", line 411, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/ben/.local/lib/python2.7/site-packages/sphinx/registry.py", line 318, in load_extension
    raise ExtensionError(__('Could not import extension %s') % extname, err)
ExtensionError: Could not import extension sphinxjp.themes.revealjs (exception: cannot import name Directive)
```
See Sphinx 1.6.5 (for example) for the warning that this was going to happen:
https://github.com/sphinx-doc/sphinx/blob/v1.6.5/sphinx/util/compat.py
```
            warnings.warn("sphinx.util.compat.%s is deprecated and will be removed "
                          "in Sphinx 1.7, please use docutils' instead." % attr,
                          RemovedInSphinx17Warning)
```