### PR TITLE
Fix Pytest4.x compatibility errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,17 +12,15 @@ class PyTest(TestCommand):
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
+        self.pytest_args = ""
 
     def run_tests(self):
+        import shlex
+
         # import here, cause outside the eggs aren't loaded
         import pytest
-        errno = pytest.main(self.pytest_args)
+
+        errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
 
 here = os.path.dirname(__file__)


### PR DESCRIPTION
This is just a copy-paste patch from
https://docs.pytest.org/en/latest/goodpractices.html#manual-integration

Fixes: https://github.com/tell-k/sphinxjp.themes.revealjs/issues/12